### PR TITLE
Add the 'String' type to DOM Node related props.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ var VueTinySlider = {
 			default: () => ['prev', 'next']
 		},
 		controlsContainer: {
-			type: [Boolean, Node],
+			type: [Boolean, Node, String],
 			default: false
 		},
 		nav: {
@@ -46,7 +46,7 @@ var VueTinySlider = {
 			default: false
 		},
 		navContainer: {
-			type: [Boolean, Node],
+			type: [Boolean, Node, String],
 			default: false
 		},
 		arrowKeys: {


### PR DESCRIPTION
Adding the 'String' type to the controlsContainer and navContainer props. The autoplayButton prop has already had string added.

This should fix the vue error that comes up when using an ID for the value of these props.