### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ For more detailed information about the methods, see the [Tiny-slider documentat
 
 2. In `nuxt.config.js` add 
 ``` js 
-plugins: [{ src: '~/plugins/vue-tiny-slider.js', ssr: false }],
+plugins: [{ src: '~/plugins/vue-tiny-slider.js', mode: 'client' }],
 ```
 
 3. Create the file `plugins/vue-tiny-slider.js` with this content


### PR DESCRIPTION
Note: Since Nuxt.js 2.4, mode has been introduced as option of plugins to specify plugin type, possible value are: client or server. ssr: false will be adapted to mode: 'client' and deprecated in next major release.

Source: https://nuxtjs.org/guide/plugins#client-side-only